### PR TITLE
Dr reformat fb output columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*_STORE # mac os x files
+*.DS_Store # alternate
+*.swp #  vi temp files
+*.o # not human readable
+*.a # not human readable
+*.pyc # not human readable
+*.viminfo
+*.sublime-workspace
+*.sublime-project
+temp/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,23 @@
-*_STORE # mac os x files
-*.DS_Store # alternate
-*.swp #  vi temp files
-*.o # not human readable
-*.a # not human readable
-*.pyc # not human readable
-*.viminfo
+*.DS_Store
 *.sublime-workspace
 *.sublime-project
 temp/*
+*.Po
+*.swp
+*.o
+Makefile
+Make
+autom*
+aclocal.m4
+compile
+config.h
+config.h.in
+config.log
+config.status
+configure
+depcomp
+install-sh
+Makefile.in
+missing
+simulate
+stamp-h1

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -45,7 +45,7 @@ The sample map file specifies which subpopulation each reference sample represen
 
 ### Output files
 
-RFMix assigns probabilities that a chunk of the genome, referred to as
+RFMix assigns probabilities that a chunk of the genome, referred to as a
 conditional random field (CRF) point, is derived from an ancestral
 population (eg. reference panel breed).
 
@@ -53,7 +53,7 @@ RFMIX upon completion will output two main files of interest: the most likely as
 
 The .msp.tsv file output file is tab separated values forming a matrix with rows corresponding to genomic position and columns corresponding to haplotypes. The file include column headers and leading columns that indicate the position or range covered for each row.
 
-For the forward-backward results, the output is the tab separated file \<output basename\>.fb.tsv
+For the forward-backward results, the output is a tab separated file with the name \<output basename\>.fb.tsv
 
 The first line is a comment line, that specifies the order of subpopulations:
 eg:
@@ -63,9 +63,9 @@ eg:
 
 The second line specifies the column names, and every following lines gives data on a chunk of the genome, called a conditional random field (CRF) point.
 
-The first few columns specifies the chromosome, genetic marker's physical position in basepair units and genetic position in centiMorgans, and the genetic marker's numerical index in the rfmix genetic map input file. The remaining columns give the probabilities that the CRF point for a genotype's haplotype was assigned to a specific reference panel population. A genotype has two haplotypes, so the number of probabilities for a genotype is 2*(number of reference panel populations). The number of columns in the file is 4 + (number of genotypes) * 2 * (number of reference panel populations.
+The first four columns specify the chromosome, genetic marker's physical position in basepair units and genetic position in centiMorgans, and the genetic marker's numerical index in the rfmix genetic map input file. The remaining columns give the probabilities that the CRF point for a genotype's haplotype was assigned to a specific reference panel population. A genotype has two haplotypes, so the number of probabilities for a genotype is 2*(number of reference panel populations). The number of columns in the file is 4 + (number of genotypes) * 2 * (number of reference panel populations.
 
-For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be::
+For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be:
 
 ```
 chromosome physical_position genetic_position genetic_marker_index

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -27,7 +27,7 @@ Run the program with no command line options to see a list of options accepted a
 The following options are required:
 
 ~~~~~~~~~~~~
-	-f <query VCF/BCF file> 
+	-f <query VCF/BCF file>
 	-r <reference VCF/BCF file>
 	-m <sample map file>
 	-g <genetic map file>
@@ -41,13 +41,17 @@ It is recommended that BCF files be used as input. The samples in the VCF/BCF fi
 
 The genetic map file is tab delimited text containing at least 3 columns. The first 3 columns are intepreted as chromosome, physical position in bp, genetic position in cM. Any number of columns or other information may follow, it is ignored. The chromosome column is a string token (which may be an string of digits) that must match those used in the VCF/BCF inputs. The genetic map file should contain the map for the entire genome (all chromosomes). Blank lines and lines beginning with a '#' are ignored.
 
-The sample map file specifies which subpopulation each reference sample represents. It is tab delimited text with at least two columns. The first column gives the sample name or identifier, which must match the one used in the reference VCF/BCF. The second column is a string naming a subpopulation and may contain spaces (e.g., "European", or "East African"). RFMIX will assign all distinct subpopulation names it finds in the sample map file an index number, in alphabetical order. The output will reference by index number; the order is given at the top of the output files. Blank lines and lines beginning with a '#' are ignored in the sample map file. Prefixing a sample with either # or \^ will exclude the sample from the reference input without needing to remove it from the reference VCF/BCF. Any sample not defined in the sample map will not be loaded from the reference VCF/BCF. This is a simple way to manipulate the content of your reference data and include or exclude entire subpopulations. 
+The sample map file specifies which subpopulation each reference sample represents. It is tab delimited text with at least two columns. The first column gives the sample name or identifier, which must match the one used in the reference VCF/BCF. The second column is a string naming a subpopulation and may contain spaces (e.g., "European", or "East African"). RFMIX will assign all distinct subpopulation names it finds in the sample map file an index number, in alphabetical order. The output will reference by index number; the order is given at the top of the output files. Blank lines and lines beginning with a '#' are ignored in the sample map file. Prefixing a sample with either # or \^ will exclude the sample from the reference input without needing to remove it from the reference VCF/BCF. Any sample not defined in the sample map will not be loaded from the reference VCF/BCF. This is a simple way to manipulate the content of your reference data and include or exclude entire subpopulations.
 
 ### Output files
 
 RFMIX upon completion will output two main files of interest: the most likely assignment of subpopulations per CRF point (\<output basename\>.msp.tsv), and the marginal probabilities of each subpopulation being the ancestral population of the corresponding CRF point (\<output basename\>.fb.tsv). The latter is produced by computing the forward-backward algorithm on the CRF, and the former by using the Viterbi algorithm. The .msp.tsv file is condensed such that CRF windows are combined if all query samples are in the sample subpopulations for successive windows. Thus, each line might represent several CRF points.
 
-Both output files are tab separated values forming a matrix with rows corresponding to genomic position and columns corresponding to haplotypes. The files include column headers and leading columns that indicate the position or range covered for each row. For the forward-backward results, haplotypes are tab delimited, but the array of probabilities for each haplotype at each window (row) is a set of space delimited columns within each tab delimited haplotype column. The order and names of the reference subpopulations are indicated in a header row. 
+The .msp.tsv file output file are tab separated values forming a matrix with rows corresponding to genomic position and columns corresponding to haplotypes. The file include column headers and leading columns that indicate the position or range covered for each row.
+
+For the forward-backward results,
+
+
 
 Global *diploid* ancestry estimates are computed by RFMIX and output to \<output basename\>.rfmix.Q, corresponding to the .Q output files of the global ancestry analysis programs *fastStructure* or *ADMIXTURE*. Please note that the ordering of subpopulations in columns for *fastStructure* or *ADMIXTURE* is not guaranteed to be the same as RFMIX and the ordering may change for different runs of those programs. RFMIX will always output in the same order (indicated in a header line) if the reference file used is the same. Additionally, RFMIX will add the sample name/id from the VCF input as a leading column.
 
@@ -70,7 +74,7 @@ The option --analyze-range=\<string\> can be used to restrict analysis only to t
 ### Limitations
 
 + The quality and accuracy of the results depends directly on the extent to which the haplotypes provided for each reference population captures the breadth of genetic diversity within that population.
-+ Single or small sample sizes often lack reference homozygote genotype calls at known variable sites and it is not possible to know from a VCF/BCF file whether read data supporting a reference homozygote call was observed. Unfortunately, this information is very informative to RFMIX and so it being censored may strongly impact results. 
++ Single or small sample sizes often lack reference homozygote genotype calls at known variable sites and it is not possible to know from a VCF/BCF file whether read data supporting a reference homozygote call was observed. Unfortunately, this information is very informative to RFMIX and so it being censored may strongly impact results.
 + Accuracy of the results, and continuity of subpopulation assignment along each haplotype, depends on the accuracy of the phasing of diploid data which must be performed separately as a pre-requisite. The phase-correction features of RFMIX, if enabled, can not correct all phasing errors and will perform poorly if the initial phasing presented to the program is poor.
 + RFMIX version 2 accepts inputs containing missing data. However, at time of writing, this feature has not been tested or studied. The rate at which results degrade for increasing amounts of missing data is not known.
 + The program will assume genotypes are phased even if the VCF file indicates they are not.
@@ -80,4 +84,3 @@ The option --analyze-range=\<string\> can be used to restrict analysis only to t
 For academic users or any other users using the program free of charge:
 
 THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM (RFMIX) "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -45,13 +45,43 @@ The sample map file specifies which subpopulation each reference sample represen
 
 ### Output files
 
+RFMix assigns probabilities that a chunk of the genome, referred to as
+conditional random field (CRF) point, is derived from an ancestral
+population (eg. reference panel breed).
+
 RFMIX upon completion will output two main files of interest: the most likely assignment of subpopulations per CRF point (\<output basename\>.msp.tsv), and the marginal probabilities of each subpopulation being the ancestral population of the corresponding CRF point (\<output basename\>.fb.tsv). The latter is produced by computing the forward-backward algorithm on the CRF, and the former by using the Viterbi algorithm. The .msp.tsv file is condensed such that CRF windows are combined if all query samples are in the sample subpopulations for successive windows. Thus, each line might represent several CRF points.
 
-The .msp.tsv file output file are tab separated values forming a matrix with rows corresponding to genomic position and columns corresponding to haplotypes. The file include column headers and leading columns that indicate the position or range covered for each row.
+The .msp.tsv file output file is tab separated values forming a matrix with rows corresponding to genomic position and columns corresponding to haplotypes. The file include column headers and leading columns that indicate the position or range covered for each row.
 
-For the forward-backward results,
+For the forward-backward results, the output is the tab separated file \<output basename\>.fb.tsv
 
+The first line is a comment line, that specifies the order of subpopulations:
+eg:
+```
+#reference_panel_population: golden_retriever  labrador_retriever  poodle  poodle_small
+```
 
+The second line specifies the column names, and every following lines gives data on a chunk of the genome, called a conditional random field (CRF) point.
+
+The first few columns specifies the chromosome, genetic marker's physical position in basepair units and genetic position in centiMorgans, and the genetic marker's numerical index in the rfmix genetic map input file. The remaining columns give the probabilities that the CRF point for a genotype's haplotype was assigned to a specific reference panel population. A genotype has two haplotypes, so the number of probabilities for a genotype is 2*(number of reference panel populations). The number of columns in the file is 4 + (number of genotypes) * 2 * (number of reference panel populations.
+
+For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be::
+
+```
+chromosome physical_position genetic_position genetic_marker_index
+genotype_id1:::hap1:::subpop1:::probability
+genotype_id1:::hap1:::subpop2:::probability
+genotype_id1:::hap1:::subpop3:::probability
+genotype_id1:::hap2:::subpop1:::probability
+genotype_id1:::hap2:::subpop2:::probability
+genotype_id1:::hap2:::subpop3:::probability
+genotype_id2:::hap1:::subpop1:::probability
+genotype_id2:::hap1:::subpop2:::probability
+genotype_id2:::hap1:::subpop3:::probability
+genotype_id2:::hap2:::subpop1:::probability
+genotype_id2:::hap2:::subpop2:::probability
+genotype_id2:::hap2:::subpop3:::probability
+```
 
 Global *diploid* ancestry estimates are computed by RFMIX and output to \<output basename\>.rfmix.Q, corresponding to the .Q output files of the global ancestry analysis programs *fastStructure* or *ADMIXTURE*. Please note that the ordering of subpopulations in columns for *fastStructure* or *ADMIXTURE* is not guaranteed to be the same as RFMIX and the ordering may change for different runs of those programs. RFMIX will always output in the same order (indicated in a header line) if the reference file used is the same. Additionally, RFMIX will add the sample name/id from the VCF input as a leading column.
 

--- a/output.cpp
+++ b/output.cpp
@@ -118,7 +118,7 @@ void msp_output(input_t *input) {
 static void fb_output_haplotype(FILE *f, int16_t *p, int n) {
   fprintf(f,"%1.5f",DF16(p[0]));
   for(int k=1; k < n; k++)
-    fprintf(f," %1.5f",DF16(p[k]));
+    fprintf(f,"\t%1.5f",DF16(p[k]));
 }
 
 #define FB_EXTENSION ".fb.tsv"
@@ -135,17 +135,24 @@ void fb_output(input_t *input) {
   }
   
   fprintf(f,"#");
-  fprintf(f,"Subpopulation order: %s", input->reference_subpops[0]);
+  fprintf(f,"Subpopulation_order:\t%s", input->reference_subpops[0]);
   for(int i=1; i < input->n_subpops; i++) {
     fprintf(f,"\t%s", input->reference_subpops[i]);
   }
   fprintf(f,"\n");
-  fprintf(f,"#chm\tpos\tgpos\tsnp idx");
+  fprintf(f,"chromosome\tphysical_pos_in_bp\tgenetic_position_in_cm\tgenetic_marker_index");
   for(int j=0; j < input->n_samples; j++) {
     sample_t *sample = input->samples + j;
     if (sample->apriori_subpop != -1 || sample->s_sample == 1) continue;
 
-    fprintf(f,"\t%s.0\t%s.1", sample->sample_id, sample->sample_id);
+    for(int k=0; k < input->n_subpops; k++) {
+      fprintf(f, "\t%s:::hap1:::%s", sample->sample_id, input->reference_subpops[k]);
+    }
+    for(int k=0; k < input->n_subpops; k++) {
+      fprintf(f, "\t%s:::hap2:::%s", sample->sample_id, input->reference_subpops[k]);
+    }
+
+    // fprintf(f,"\t%s.0\t%s.1", sample->sample_id, sample->sample_id);
   }
   fprintf(f,"\n");
 

--- a/output.cpp
+++ b/output.cpp
@@ -122,20 +122,15 @@ static void fb_output_haplotype(FILE *f, int16_t *p, int n) {
 
 #define FB_EXTENSION ".fb.tsv"
 void fb_output(input_t *input) {
-// the output is the tab separated file \<output basename\>.fb.tsv
-
+// the output is a tab separated file with the name \<output basename\>.fb.tsv
+//
 // The first line is a comment line, that specifies the order of subpopulations:
 // eg:
-
 //   #reference_panel_population: golden_retriever  labrador_retriever  poodle  poodle_small
-
 // The second line specifies the column names, and every following lines gives data on a chunk of the genome, called a conditional random field (CRF) point.
-
 // The first few columns specifies the chromosome, genetic marker's physical position in basepair units and genetic position in centiMorgans, and the genetic marker's numerical index in the rfmix genetic map input file. The remaining columns give the probabilities that the CRF point for a genotype's haplotype was assigned to a specific reference panel population. A genotype has two haplotypes, so the number of probabilities for a genotype is 2*(number of reference panel populations). The number of columns in the file is 4 + (number of genotypes) * 2 * (number of reference panel populations.
-
-// For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be::
-
-
+//
+// For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be:
 //   chromosome physical_position genetic_position genetic_marker_index 
 //   genotype_id1:::hap1:::subpop1:::probability
 //   genotype_id1:::hap1:::subpop2:::probability

--- a/output.cpp
+++ b/output.cpp
@@ -84,7 +84,6 @@ void msp_output(input_t *input) {
     fprintf(stderr,"Can't open output file %s (%s)\n", fname, strerror(errno));
     exit(-1);
   }
-  
   fprintf(f,"#");
   fprintf(f,"Subpopulation order/codes: %s=0", input->reference_subpops[0]);
   for(int i=1; i < input->n_subpops; i++) {
@@ -123,6 +122,34 @@ static void fb_output_haplotype(FILE *f, int16_t *p, int n) {
 
 #define FB_EXTENSION ".fb.tsv"
 void fb_output(input_t *input) {
+// the output is the tab separated file \<output basename\>.fb.tsv
+
+// The first line is a comment line, that specifies the order of subpopulations:
+// eg:
+
+//   #reference_panel_population: golden_retriever  labrador_retriever  poodle  poodle_small
+
+// The second line specifies the column names, and every following lines gives data on a chunk of the genome, called a conditional random field (CRF) point.
+
+// The first few columns specifies the chromosome, genetic marker's physical position in basepair units and genetic position in centiMorgans, and the genetic marker's numerical index in the rfmix genetic map input file. The remaining columns give the probabilities that the CRF point for a genotype's haplotype was assigned to a specific reference panel population. A genotype has two haplotypes, so the number of probabilities for a genotype is 2*(number of reference panel populations). The number of columns in the file is 4 + (number of genotypes) * 2 * (number of reference panel populations.
+
+// For example, for a rfmix run with 2 admixed genotype_ids run against 3 reference panel populations, the columns would be::
+
+
+//   chromosome physical_position genetic_position genetic_marker_index 
+//   genotype_id1:::hap1:::subpop1:::probability
+//   genotype_id1:::hap1:::subpop2:::probability
+//   genotype_id1:::hap1:::subpop3:::probability
+//   genotype_id1:::hap2:::subpop1:::probability
+//   genotype_id1:::hap2:::subpop2:::probability
+//   genotype_id1:::hap2:::subpop3:::probability
+//   genotype_id2:::hap1:::subpop1:::probability
+//   genotype_id2:::hap1:::subpop2:::probability
+//   genotype_id2:::hap1:::subpop3:::probability
+//   genotype_id2:::hap2:::subpop1:::probability
+//   genotype_id2:::hap2:::subpop2:::probability
+//   genotype_id2:::hap2:::subpop3:::probability
+
   fprintf(stderr,"Outputing forward-backward results.... \n");
   int fname_length = strlen(rfmix_opts.output_basename) + strlen(FB_EXTENSION) + 1;
   char fname[fname_length];
@@ -135,21 +162,21 @@ void fb_output(input_t *input) {
   }
   
   fprintf(f,"#");
-  fprintf(f,"Subpopulation_order:\t%s", input->reference_subpops[0]);
+  fprintf(f,"reference_panel_population:\t%s", input->reference_subpops[0]);
   for(int i=1; i < input->n_subpops; i++) {
     fprintf(f,"\t%s", input->reference_subpops[i]);
   }
   fprintf(f,"\n");
-  fprintf(f,"chromosome\tphysical_pos_in_bp\tgenetic_position_in_cm\tgenetic_marker_index");
+  fprintf(f,"chromosome\tphysical_position\tgenetic_position\tgenetic_marker_index");
   for(int j=0; j < input->n_samples; j++) {
     sample_t *sample = input->samples + j;
     if (sample->apriori_subpop != -1 || sample->s_sample == 1) continue;
 
     for(int k=0; k < input->n_subpops; k++) {
-      fprintf(f, "\t%s:::hap1:::%s", sample->sample_id, input->reference_subpops[k]);
+      fprintf(f, "\t%s:::hap1:::%s:::probability", sample->sample_id, input->reference_subpops[k]);
     }
     for(int k=0; k < input->n_subpops; k++) {
-      fprintf(f, "\t%s:::hap2:::%s", sample->sample_id, input->reference_subpops[k]);
+      fprintf(f, "\t%s:::hap2:::%s:::probability", sample->sample_id, input->reference_subpops[k]);
     }
 
     // fprintf(f,"\t%s.0\t%s.1", sample->sample_id, sample->sample_id);


### PR DESCRIPTION
reformats fb.tsv output for easier pandas parsing

  * changes delimiter for crf assignment probabilities from ' ' to '\t'
  * expands header columns so that every reference panel subpop assignment probability has a column name
  * gives more verbose column names
  * adds comments in code to give example output lines

updates MANUAL.md to reflect file format change
