### PR TITLE
Add docker target to Makefile; run autoupdate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04 as builder
+
+RUN apt -y update -qq && apt -y upgrade && \
+	DEBIAN_FRONTEND=noninteractive apt -y install \
+	autoconf automake gawk gcc g++ clang make software-properties-common vim 
+
+WORKDIR /usr/src 
+
+# Put the code into a subdir, so we don't copy the Makefile and 
+# Dockerfile into the container, they are not needed here.
+COPY . .
+
+RUN autoupdate && autoreconf && ./configure && make && make install
+
+FROM ubuntu:22.04 as runtime
+
+COPY --from=builder /usr/local/bin/rfmix /usr/local/bin/simulate \
+	/usr/local/bin/
+
+# we map the user owning the image so permissions for any mapped 
+# input/output paths set by the user will work correctly
+CMD rfmix

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,3 +8,5 @@ rfmix_SOURCES = cmdline-utils.c inputline.cpp genetic-map.cpp md5rng.cpp hash-ta
 
 simulate_SOURCES = cmdline-utils.c inputline.cpp genetic-map.cpp hash-table.cpp vcf.cpp simulate.cpp s-sample.cpp s-subpop.cpp
 
+docker: Dockerfile
+	docker build -t rfmix:latest .

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.62])
-AC_INIT([RFMIX], [v2.03-r0], markoni.wright@gmail.com)
+AC_PREREQ([2.71])
+AC_INIT([RFMIX],[v2.03-r0],[markoni.wright@gmail.com])
 AC_CONFIG_SRCDIR([./rfmix.cpp])
 AM_INIT_AUTOMAKE
 
@@ -33,4 +33,5 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([gettimeofday memset strdup strerror strtol strtoul])
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
This builds rfmix in a container, that can be used to derive an Apptainer or Singularity image as well.

Signed-off-by: Sven-Thorsten Dietrich <sxd1425@miami.edu>
